### PR TITLE
Update expert_rules.ipynb

### DIFF
--- a/doc/source/rst/tutorials/expert_rules.ipynb
+++ b/doc/source/rst/tutorials/expert_rules.ipynb
@@ -128,7 +128,7 @@
     "from rulekit.classification import ExpertRuleClassifier\n",
     "\n",
     "clf = ExpertRuleClassifier(\n",
-    "    min_rule_covered = 8,\n",
+    "    minsupp_new = 8,\n",
     "    max_growing= 0,\n",
     "    extend_using_preferred=True,\n",
     "    extend_using_automatic=True,\n",


### PR DESCRIPTION
According to documentation [here](https://adaa-polsl.github.io/RuleKit-python/rst/autodoc/classification.html?highlight=expert#rulekit.classification.ExpertRuleClassifier), and warning: DeprecationWarning: "min_rule_covered" parameter was renamed to "minsupp_new" and is now deprecated, "minsupp_new" instead. "min_rule_covered" parameter will be removed in next major version of the package.

Fixed parameter to match newest version and remove deprecation warning.