### PR TITLE
Feat user defined measures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -294,3 +294,4 @@ classification_tabular_datasets/
 .coverage
 junit.xml
 a.ipynb
+java.logs

--- a/rulekit/_helpers.py
+++ b/rulekit/_helpers.py
@@ -49,6 +49,7 @@ class RuleGeneratorConfigurator:
     _MEASURES_PARAMETERS: list[str] = [
         'induction_measure', 'pruning_measure', 'voting_measure',
     ]
+    _USER_DEFINED_MEASURE_VALUE: str = 'UserDefined'
 
     def __init__(self, rule_generator):
         self.rule_generator = rule_generator
@@ -104,13 +105,17 @@ class RuleGeneratorConfigurator:
             if isinstance(param_value, Callable):
                 self._configure_user_defined_measure_parameter(
                     param_name, param_value)
-                self.rule_generator.setParameter(param_name, 'UserDefined')
-                self.rule_generator.setParameter(param_name, param_value)
 
     def _configure_user_defined_measure_parameter(self, param_name: str, param_value: Any):
-        if param_value is not None:
-            self.rule_generator.setParameter(param_name, 'UserDefined')
-            self.rule_generator.setParameter(param_name, param_value)
+        from rulekit.params import _user_defined_measure_factory
+        user_defined_measure = _user_defined_measure_factory(param_value)
+        {
+            'induction_measure': self.rule_generator.setUserMeasureInductionObject,
+            'pruning_measure': self.rule_generator.setUserMeasurePurningObject,
+            'voting_measure': self.rule_generator.setUserMeasureVotingObject,
+        }[param_name](user_defined_measure)
+        self.rule_generator.setParameter(
+            param_name, self._USER_DEFINED_MEASURE_VALUE)
 
     def _configure_rule_generator(self, **kwargs: dict[str, Any]):
         if any([kwargs.get(param_name) == Measures.LogRank for param_name in self._MEASURES_PARAMETERS]):
@@ -135,6 +140,15 @@ class RuleGeneratorConfigurator:
             ValueError: If failed to retrieve RuleGenerator parameters JSON
             RuleKitMisconfigurationException: If Java and Python parameters do not match
         """
+        def are_params_equal(java_params: dict[str, Any], python_params: dict[str, Any]):
+            if java_params.keys() != python_params.keys():
+                return False
+            for key in java_params.keys():
+                skip_check: bool = isinstance(python_params[key], Callable)
+                if java_params[key] != python_params[key] and not skip_check:
+                    return False
+            return True
+
         python_parameters = dict(python_parameters)
         for param_name, param_value in python_parameters.items():
             # convert measures to strings values for comparison
@@ -162,7 +176,7 @@ class RuleGeneratorConfigurator:
             param_name: str(java_params[param_name])
             for param_name in python_parameters.keys()
         }
-        if java_params != python_parameters:
+        if not are_params_equal(java_params, python_parameters):
             raise RuleKitMisconfigurationException(
                 java_parameters=java_params,
                 python_parameters=python_parameters

--- a/rulekit/exceptions.py
+++ b/rulekit/exceptions.py
@@ -1,5 +1,6 @@
 """Module containing classes for handling exceptions."""
 from typing import Any
+from typing import Callable
 
 from jpype import JException
 
@@ -71,7 +72,9 @@ class RuleKitMisconfigurationException(Exception):
             java_value = java_parameters.get(key)
             python_value = python_parameters.get(key)
             line: str = f'  {key}: ({java_value},  {python_value}),'
-            if java_value != python_value:
+            # skip check for user defined measures
+            skip_check: bool = isinstance(python_value, Callable)
+            if java_value != python_value and not skip_check:
                 line = f'{line} <-- **DIFFERENT**'
             params_lines.append(line)
         message: str = (

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -11,6 +11,7 @@ from sklearn.datasets import load_iris
 
 from rulekit import classification
 from rulekit.events import RuleInductionProgressListener
+from rulekit.params import Measures
 from rulekit.rules import Rule
 from tests.utils import assert_accuracy_is_greater
 from tests.utils import assert_rules_are_equals
@@ -281,6 +282,49 @@ class TestExperClassifier(unittest.TestCase):
             expert_preferred_conditions=expert_preferred_conditions,
             expert_forbidden_conditions=expert_forbidden_conditions
         )
+
+    def test_user_defined_measures(self):
+        def full_coverage(p: float, n: float, P: float, N: float) -> float:
+            return (p + n) / (P + N)
+
+        python_clf = classification.RuleClassifier(
+            induction_measure=full_coverage,
+            pruning_measure=full_coverage,
+            voting_measure=full_coverage,
+        )
+        java_clf = classification.RuleClassifier(
+            induction_measure=Measures.FullCoverage,
+            pruning_measure=Measures.FullCoverage,
+            voting_measure=Measures.FullCoverage,
+        )
+        x, y = load_iris(return_X_y=True)
+
+        python_clf.fit(x, y)
+        java_clf.fit(x, y)
+
+        self.assertEqual(
+            [r.weight for r in python_clf.model.rules],
+            [r.weight for r in java_clf.model.rules],
+            'Weights should be equal'
+        )
+        self.assertEqual(
+            [str(r) for r in python_clf.model.rules],
+            [str(r) for r in java_clf.model.rules],
+            'Rules should be equal'
+        )
+
+        def zero_measure(p: float, n: float, P: float, N: float) -> float:
+            return 0.0
+
+        python_clf2 = classification.RuleClassifier(
+            induction_measure=Measures.FullCoverage,
+            pruning_measure=Measures.FullCoverage,
+            voting_measure=zero_measure,
+        )
+        python_clf2.fit(x, y)
+        self.assertTrue(all([
+            r.weight == 0.0 for r in python_clf2.model.rules
+        ]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Users can now define custom quality measures function and use them for: growing, pruning and voting. Defining quality measure function is easy and straightforward, see example below. 

```python
from rulekit.classification import RuleClassifier

def my_induction_measure(p: float, n: float, P: float, N: float) -> float:
    # do anything you want here and return a single float...
    return (p + n) / (P + N)

def my_pruning_measure(p: float, n: float, P: float, N: float) -> float:
    return p - n

def my_voting_measure(p: float, n: float, P: float, N: float) -> float:
    return (p + 1) / (p + n + 2)

python_clf = RuleClassifier(
    induction_measure=my_induction_measure,
    pruning_measure=my_pruning_measure,
    voting_measure=my_voting_measure,
)
```