### PR TITLE
Fix/jpype version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setuptools.setup(
         'pandas>=1.5',
         'scipy>=1.11',
         'scikit-learn>=1.1',
-        'JPype1>=1.5.0',
+        'JPype1==1.5.2',
         'pydantic>=2.0',
         'requests>=2.32.3',
     ],

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with io.open("README.md", mode="r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="rulekit",
-    version='2.1.24.1',
+    version='2.1.24.2',
     author="Cezary Maszczyk",
     author_email="cezary.maszczyk@gmail.com",
     description="Comprehensive suite for rule-based learning",


### PR DESCRIPTION
Fix problem with new jpype1 version, which was causing problems. New Jpype1 1.6.0 was released 07.07 and after that some of the unit tests stopped working throwing error: C [_jpype.cpython-313-x86_64-linux-gnu.so+0x7653b] JPTypeManager::findClassByName(std::string const&)+0x3b
Configuration in setup.py was changed from ‘JPype1>=1.5.0’ to ‘JPype1==1.5.2’ so that the latest working version would install